### PR TITLE
Add CodeCompanion plugin

### DIFF
--- a/config/lua/config/keymaps.lua
+++ b/config/lua/config/keymaps.lua
@@ -1,3 +1,10 @@
 -- Keymaps are automatically loaded on the VeryLazy event
 -- Default keymaps that are always set: https://github.com/LazyVim/LazyVim/blob/main/lua/lazyvim/config/keymaps.lua
 -- Add any additional keymaps here
+vim.api.nvim_set_keymap(
+  "n",
+  "<leader>Ca",
+  ":CodeCompanionAction<CR>",
+  { desc = "Action", noremap = true, silent = true }
+)
+vim.api.nvim_set_keymap("n", "<leader>Cc", ":CodeCompanionChat<CR>", { desc = "Chat", noremap = true, silent = true })

--- a/config/lua/plugins/codecompanion.lua
+++ b/config/lua/plugins/codecompanion.lua
@@ -1,0 +1,27 @@
+return {
+  {
+    "olimorris/codecompanion.nvim",
+    event = "VeryLazy",
+    config = function(_, _)
+      require("codecompanion").setup({
+        display = {
+          action_palette = {
+            width = 95,
+            height = 10,
+            prompt = "Prompt ", -- Prompt used for interactive LLM calls
+            provider = "default", -- Can be "default", "telescope", or "mini_pick". If not specified, the plugin will autodetect installed providers.
+            opts = {
+              show_default_actions = true, -- Show the default actions in the action palette?
+              show_default_prompt_library = true, -- Show the default prompt library in the action palette?
+            },
+          },
+        },
+      })
+    end,
+    dependencies = {
+
+      "nvim-lua/plenary.nvim",
+      "nvim-treesitter/nvim-treesitter",
+    },
+  },
+}

--- a/nix/plugins.nix
+++ b/nix/plugins.nix
@@ -24,6 +24,7 @@
     # bufdelete-nvim
     bufferline-nvim
     catppuccin-nvim
+    codecompanion-nvim
     conform-nvim
     # copilot-cmp
     copilot-lua
@@ -56,6 +57,7 @@
     mini-nvim
     mini-move
     mini-pairs
+    mini-pick
     mini-surround
     neo-tree-nvim
     # neogit


### PR DESCRIPTION
- Introduces the `codecompanion-nvim` plugin for code assistance.
- Adds keymaps `<leader>Ca` to trigger CodeCompanion Action and `<leader>Cc` to trigger CodeCompanion Chat.
- Configures the CodeCompanion plugin with a default setup, including the action palette.
- Adds dependencies `plenary.nvim`, `nvim-treesitter`, and `mini-pick` to the plugin list in `plugins.nix`.